### PR TITLE
fix(user-service): permit actuator health endpoint for Render health …

### DIFF
--- a/foodieHub/src/main/java/com/project/foodieHub/config/SecurityConfig.java
+++ b/foodieHub/src/main/java/com/project/foodieHub/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
   public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
     return httpSecurity.csrf(AbstractHttpConfigurer::disable)
         .cors(AbstractHttpConfigurer::disable)
-        .authorizeHttpRequests(request -> request.requestMatchers("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/refresh-token", "/api/v1/contact", "/api/v1/slides", "/api/v1/partner/register", "/api/v1/driver/register", "/api/v1/internal/**", "/oauth2/**", "/login/oauth2/**").permitAll())
+        .authorizeHttpRequests(request -> request.requestMatchers("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/refresh-token", "/api/v1/contact", "/api/v1/slides", "/api/v1/partner/register", "/api/v1/driver/register", "/api/v1/internal/**", "/oauth2/**", "/login/oauth2/**", "/actuator/health", "/actuator/info").permitAll())
         .authorizeHttpRequests(request -> request.requestMatchers("/api/v1/**").authenticated())
         .oauth2Login(httpSecurityOAuth2LoginConfigurer -> httpSecurityOAuth2LoginConfigurer
             .authorizationEndpoint(authorizationEndpointConfig -> authorizationEndpointConfig.authorizationRequestResolver(


### PR DESCRIPTION
…checks

Spring Security 6 denies unmatched requests by default, causing Render's unauthenticated health checker to receive 401 instead of 200 and time out.