### PR TITLE
fix(food-service): inject X-Elastic-Product response header for ES 7.…

### DIFF
--- a/food-service/src/main/java/com/project/foodservice/config/ElasticsearchConfig.java
+++ b/food-service/src/main/java/com/project/foodservice/config/ElasticsearchConfig.java
@@ -1,6 +1,7 @@
 package com.project.foodservice.config;
 
 import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.impl.client.BasicCredentialsProvider;
@@ -43,6 +44,16 @@ public class ElasticsearchConfig {
                         (HttpRequestInterceptor) (request, context) -> {
                             request.setHeader("Content-Type", "application/json");
                             request.setHeader("Accept", "application/json");
+                        }
+                    );
+
+                    // elasticsearch-java 8.x checks every response for the
+                    // X-Elastic-Product header that ES 7.x doesn't send — inject it.
+                    httpClientBuilder.addInterceptorLast(
+                        (HttpResponseInterceptor) (response, context) -> {
+                            if (response.getFirstHeader("X-Elastic-Product") == null) {
+                                response.addHeader("X-Elastic-Product", "Elasticsearch");
+                            }
                         }
                     );
 


### PR DESCRIPTION
…x compatibility

elasticsearch-java 8.x validates every response for the X-Elastic-Product header introduced in ES 7.14+. Bonsai free tier (ES 7.10) doesn't send it, causing a TransportException even on successful 200 responses. Add an HC4 response interceptor that injects the missing header so the product check passes.