### PR TITLE
fix(api-gateway): merge duplicate management blocks, use env var for …

### DIFF
--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -326,11 +326,9 @@ management:
   health:
     circuitbreakers:
       enabled: true
-
-management:
   tracing:
     sampling:
-      probability: 1.0
+      probability: ${TRACING_SAMPLING_PROBABILITY:0.0}
   zipkin:
     tracing:
       endpoint: ${ZIPKIN_URL:http://localhost:9411}/api/v2/spans


### PR DESCRIPTION
…tracing

Two management: top-level keys in application.yaml caused the second block to silently override the first, dropping endpoint exposure and circuit breaker health config. Merged into one block and switched tracing probability to use TRACING_SAMPLING_PROBABILITY env var (default 0.0).