### PR TITLE
fix(oauth2): route Google callback through API gateway instead of use…

### DIFF
--- a/foodieHub-FE/src/app/login/login.component.ts
+++ b/foodieHub-FE/src/app/login/login.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { environment } from '../../environments/environment';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -108,7 +109,7 @@ export class LoginComponent implements OnInit, OnDestroy {
 
   signInWithGoogle() {
     const deviceId = this.deviceService.getDeviceId();
-    window.location.href = `http://localhost:8080/oauth2/authorization/google?deviceId=${encodeURIComponent(deviceId)}`;
+    window.location.href = `${environment.apiBaseUrl}/oauth2/authorization/google?deviceId=${encodeURIComponent(deviceId)}`;
   }
 
   get pwd() { return this.loginForm.get('pwd'); }

--- a/user-service/src/main/java/com/project/foodieHub/config/CustomOAuth2SuccessHandler.java
+++ b/user-service/src/main/java/com/project/foodieHub/config/CustomOAuth2SuccessHandler.java
@@ -84,8 +84,10 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
     var refreshToken = refreshTokenService.createRefreshToken(user, deviceId);
     redisTemplate.opsForValue().set(user.getUsername()+deviceId, token, Duration.ofMillis(jwtExpiration)); //store token in redis
 
+    String frontendUrl = System.getenv().getOrDefault("FRONTEND_URL", "http://localhost:4200");
     String redirectUrl = String.format(
-        "http://localhost:4200/google-callback?accessToken=%s&refreshToken=%s",
+        "%s/google-callback?accessToken=%s&refreshToken=%s",
+        frontendUrl,
         URLEncoder.encode(token, StandardCharsets.UTF_8),
         URLEncoder.encode(refreshToken.getToken(), StandardCharsets.UTF_8)
     );

--- a/user-service/src/main/resources/application.yaml
+++ b/user-service/src/main/resources/application.yaml
@@ -29,7 +29,7 @@ spring:
             client-id: ${GOOGLE-CLIENT-ID}
             client-secret: ${GOOGLE-SECRET}
             scope: email, profile
-            redirect-uri: ${APP_URL:http://localhost:8081}/login/oauth2/code/google
+            redirect-uri: ${GATEWAY_URL:http://localhost:8080}/login/oauth2/code/google
         provider:
           google:
             authorization-uri: https://accounts.google.com/o/oauth2/v2/auth


### PR DESCRIPTION
…r-service directly

- redirect-uri now uses GATEWAY_URL env var (defaults to localhost:8080) so the OAuth2 callback goes through the gateway on all environments
- Frontend FRONTEND_URL env var (defaults to localhost:4200) replaces hardcoded URL in success handler
- Angular signInWithGoogle() uses environment.apiBaseUrl instead of hardcoded localhost:8080